### PR TITLE
FIX Run other middleware delegates before adding HTMLEditorConfig settings

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -15,6 +15,11 @@ Ensure that your server is setup with [hunspell](http://hunspell.sourceforge.net
 Install the spellcheck module with composer, using `composer require silverstripe/spellcheck ^2.0`, or downloading
 the module and extracting to the 'spellcheck' directory under your project root.
 
+## Requirements
+
+* SilverStripe 4.0.2 or above
+* Hunspell
+
 **Note:** this version is compatible with SilverStripe 4. For SilverStripe 3, please see [the 1.x release line](https://github.com/silverstripe/silverstripe-spellcheck/tree/1.0).
 
 ## Configuration

--- a/src/Handling/SpellCheckMiddleware.php
+++ b/src/Handling/SpellCheckMiddleware.php
@@ -3,6 +3,7 @@
 namespace SilverStripe\SpellCheck\Handling;
 
 use SilverStripe\Control\HTTPRequest;
+use SilverStripe\Control\HTTPResponse;
 use SilverStripe\Control\Middleware\HTTPMiddleware;
 use SilverStripe\Core\Config\Configurable;
 use SilverStripe\Forms\HTMLEditor\HTMLEditorConfig;
@@ -23,25 +24,29 @@ class SpellCheckMiddleware implements HTTPMiddleware
 
     public function process(HTTPRequest $request, callable $delegate)
     {
+        /** @var HTTPResponse $response */
+        $response = $delegate($request);
+
         // Set settings
         $editor = static::config()->get('editor');
         HTMLEditorConfig::get($editor)->enablePlugins('spellchecker');
         HTMLEditorConfig::get($editor)->addButtonsToLine(2, 'spellchecker');
         $token = SecurityToken::inst();
-        HTMLEditorConfig::get($editor)->setOption('spellchecker_rpc_url', $token->addToUrl('spellcheck/'));
-        HTMLEditorConfig::get($editor)->setOption('browser_spellcheck', false);
-        HTMLEditorConfig::get($editor)->setOption(
-            'spellchecker_languages',
-            '+'.implode(', ', $this->getLanguages())
-        );
+        HTMLEditorConfig::get($editor)
+            ->setOption('spellchecker_rpc_url', $token->addToUrl('spellcheck/'))
+            ->setOption('browser_spellcheck', false)
+            ->setOption(
+                'spellchecker_languages',
+                '+' . implode(', ', $this->getLanguages())
+            );
 
-        return $delegate($request);
+        return $response;
     }
 
     /**
      * Check languages to set
      *
-     * @return array
+     * @return string[]
      */
     public function getLanguages()
     {


### PR DESCRIPTION
Part of the fix for https://github.com/silverstripe/silverstripe-spellcheck/issues/33