### PR TITLE
API Refactor input and output format for TinyMCE 4 compatibility

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -15,6 +15,11 @@ Ensure that your server is setup with [hunspell](http://hunspell.sourceforge.net
 Install the spellcheck module with composer, using `composer require silverstripe/spellcheck ^2.0`, or downloading
 the module and extracting to the 'spellcheck' directory under your project root.
 
+## Requirements
+
+* SilverStripe 4.0.2 or above
+* Hunspell
+
 **Note:** this version is compatible with SilverStripe 4. For SilverStripe 3, please see [the 1.x release line](https://github.com/silverstripe/silverstripe-spellcheck/tree/1.0).
 
 ## Configuration

--- a/src/Handling/SpellCheckMiddleware.php
+++ b/src/Handling/SpellCheckMiddleware.php
@@ -2,6 +2,7 @@
 
 namespace SilverStripe\SpellCheck\Handling;
 
+use SilverStripe\Control\Director;
 use SilverStripe\Control\HTTPRequest;
 use SilverStripe\Control\Middleware\HTTPMiddleware;
 use SilverStripe\Core\Config\Configurable;
@@ -28,12 +29,13 @@ class SpellCheckMiddleware implements HTTPMiddleware
         HTMLEditorConfig::get($editor)->enablePlugins('spellchecker');
         HTMLEditorConfig::get($editor)->addButtonsToLine(2, 'spellchecker');
         $token = SecurityToken::inst();
-        HTMLEditorConfig::get($editor)->setOption('spellchecker_rpc_url', $token->addToUrl('spellcheck/'));
-        HTMLEditorConfig::get($editor)->setOption('browser_spellcheck', false);
-        HTMLEditorConfig::get($editor)->setOption(
-            'spellchecker_languages',
-            '+'.implode(', ', $this->getLanguages())
-        );
+        HTMLEditorConfig::get($editor)
+            ->setOption('spellchecker_rpc_url', Director::absoluteURL($token->addToUrl('spellcheck/')))
+            ->setOption('browser_spellcheck', false)
+            ->setOption(
+                'spellchecker_languages',
+                implode(',', $this->getLanguages())
+            );
 
         return $delegate($request);
     }
@@ -41,7 +43,7 @@ class SpellCheckMiddleware implements HTTPMiddleware
     /**
      * Check languages to set
      *
-     * @return array
+     * @return string[]
      */
     public function getLanguages()
     {

--- a/src/Handling/SpellController.php
+++ b/src/Handling/SpellController.php
@@ -165,12 +165,8 @@ class SpellController extends Controller
         }
 
         // Check locale
-        $locale = $data['lang'];
-
-        // Check if the locale is actually a language
-        $locale = i18n::getData()->localeFromLang($locale);
-
-        if (!in_array($locale, self::get_locales())) {
+        $locale = $this->getLocale($data);
+        if (!$locale) {
             return $this->error(_t(__CLASS__ . '.InvalidLocale', 'Not supported locale'), 400);
         }
 
@@ -252,5 +248,27 @@ class SpellController extends Controller
             $this->data = $this->request->postVars();
         }
         return $this->data;
+    }
+
+    /**
+     * Get the locale from the provided "lang" argument, which could be either a language code or locale
+     *
+     * @param array $data
+     * @return string|false
+     */
+    protected function getLocale(array $data)
+    {
+        $locale = $data['lang'];
+
+        // Check if the locale is actually a language
+        if (strpos($locale, '_') === false) {
+            $locale = i18n::getData()->localeFromLang($locale);
+        }
+
+        if (!in_array($locale, self::get_locales())) {
+            return false;
+        }
+
+        return $locale;
     }
 }

--- a/tests/SpellControllerTest.php
+++ b/tests/SpellControllerTest.php
@@ -71,7 +71,7 @@ class SpellControllerTest extends FunctionalTest
         $response = $this->get('spellcheck', Injector::inst()->create(Session::class, $session));
         $this->assertEquals(400, $response->getStatusCode());
         $jsonBody = json_decode($response->getBody());
-        $this->assertEquals($tokenError, $jsonBody->error->errstr);
+        $this->assertEquals($tokenError, $jsonBody->error);
 
         // Test request with correct token (will fail with an unrelated error)
         $response = $this->get(
@@ -79,13 +79,13 @@ class SpellControllerTest extends FunctionalTest
             Injector::inst()->create(Session::class, $session)
         );
         $jsonBody = json_decode($response->getBody());
-        $this->assertNotEquals($tokenError, $jsonBody->error->errstr);
+        $this->assertNotEquals($tokenError, $jsonBody->error);
 
         // Test request with check disabled
         Config::modify()->set(SpellController::class, 'enable_security_token', false);
         $response = $this->get('spellcheck', Injector::inst()->create(Session::class, $session));
         $jsonBody = json_decode($response->getBody());
-        $this->assertNotEquals($tokenError, $jsonBody->error->errstr);
+        $this->assertNotEquals($tokenError, $jsonBody->error);
     }
 
     /**
@@ -102,20 +102,20 @@ class SpellControllerTest extends FunctionalTest
         $this->logInWithPermission('ADMIN');
         $response = $this->get('spellcheck');
         $jsonBody = json_decode($response->getBody());
-        $this->assertNotEquals($securityError, $jsonBody->error->errstr);
+        $this->assertNotEquals($securityError, $jsonBody->error);
 
         // Test insufficient permissions
         $this->logInWithPermission('CMS_ACCESS_CMSMain');
         $response = $this->get('spellcheck');
         $this->assertEquals(403, $response->getStatusCode());
         $jsonBody = json_decode($response->getBody());
-        $this->assertEquals($securityError, $jsonBody->error->errstr);
+        $this->assertEquals($securityError, $jsonBody->error);
 
         // Test disabled permissions
         Config::modify()->set(SpellController::class, 'required_permission', false);
         $response = $this->get('spellcheck');
         $jsonBody = json_decode($response->getBody());
-        $this->assertNotEquals($securityError, $jsonBody->error->errstr);
+        $this->assertNotEquals($securityError, $jsonBody->error);
     }
 
     /**
@@ -128,47 +128,29 @@ class SpellControllerTest extends FunctionalTest
         Config::modify()->set(SpellController::class, 'required_permission', false);
         $invalidRequest = _t('SilverStripe\\SpellCheck\\Handling\\SpellController.InvalidRequest', 'Invalid request');
 
-        // Test checkWords acceptance
-        $dataCheckWords = array(
-            'id' => 'c0',
-            'method' => 'checkWords',
-            'params' => array(
-                'en_NZ',
-                array('collor', 'colour', 'color', 'onee', 'correct')
-            )
-        );
-        $response = $this->post('spellcheck', array('ajax' => 1, 'json_data' => json_encode($dataCheckWords)));
+        // Test spellcheck acceptance
+        $mockData = [
+            'method' => 'spellcheck',
+            'lang' => 'en_NZ',
+            'text' => 'Collor is everywhere',
+        ];
+        $response = $this->post('spellcheck', ['ajax' => true] + $mockData);
         $this->assertEquals(200, $response->getStatusCode());
         $jsonBody = json_decode($response->getBody());
-        $this->assertEquals('c0', $jsonBody->id);
-        $this->assertEquals(array("collor", "color", "onee"), $jsonBody->result);
-
-        // Test getSuggestions acceptance
-        $dataGetSuggestions = array(
-            'id' => '//c1//', // Should be reduced to only alphanumeric characters
-            'method' => 'getSuggestions',
-            'params' => array(
-                'en_NZ',
-                'collor'
-
-            )
-        );
-        $response = $this->post('spellcheck', array('ajax' => 1, 'json_data' => json_encode($dataGetSuggestions)));
-        $this->assertEquals(200, $response->getStatusCode());
-        $jsonBody = json_decode($response->getBody());
-        $this->assertEquals('c1', $jsonBody->id);
-        $this->assertEquals(array('collar', 'colour'), $jsonBody->result);
+        $this->assertNotEmpty($jsonBody->words);
+        $this->assertNotEmpty($jsonBody->words->collor);
+        $this->assertEquals(['collar', 'colour'], $jsonBody->words->collor);
 
         // Test non-ajax rejection
-        $response = $this->post('spellcheck', array('json_data' => json_encode($dataCheckWords)));
+        $response = $this->post('spellcheck', $mockData);
         $this->assertEquals(400, $response->getStatusCode());
         $jsonBody = json_decode($response->getBody());
-        $this->assertEquals($invalidRequest, $jsonBody->error->errstr);
+        $this->assertEquals($invalidRequest, $jsonBody->error);
 
         // Test incorrect method
-        $dataInvalidMethod = $dataCheckWords;
+        $dataInvalidMethod = $mockData;
         $dataInvalidMethod['method'] = 'validate';
-        $response = $this->post('spellcheck', array('ajax' => 1, 'json_data' => json_encode($dataInvalidMethod)));
+        $response = $this->post('spellcheck', ['ajax' => true] + $dataInvalidMethod);
         $this->assertEquals(400, $response->getStatusCode());
         $jsonBody = json_decode($response->getBody());
         $this->assertEquals(
@@ -177,29 +159,27 @@ class SpellControllerTest extends FunctionalTest
                 "Unsupported method '{method}'",
                 array('method' => 'validate')
             ),
-            $jsonBody->error->errstr
+            $jsonBody->error
         );
 
         // Test missing method
-        $dataNoMethod = $dataCheckWords;
+        $dataNoMethod = $mockData;
         unset($dataNoMethod['method']);
-        $response = $this->post('spellcheck', array('ajax' => 1, 'json_data' => json_encode($dataNoMethod)));
+        $response = $this->post('spellcheck', ['ajax' => true] + $dataNoMethod);
         $this->assertEquals(400, $response->getStatusCode());
         $jsonBody = json_decode($response->getBody());
-        $this->assertEquals($invalidRequest, $jsonBody->error->errstr);
+        $this->assertEquals($invalidRequest, $jsonBody->error);
 
         // Test unsupported locale
-        $dataWrongLocale = $dataCheckWords;
-        $dataWrongLocale['params'] = array(
-            'de_DE',
-            array('collor', 'colour', 'color', 'onee', 'correct')
-        );
-        $response = $this->post('spellcheck', array('ajax' => 1, 'json_data' => json_encode($dataWrongLocale)));
+        $dataWrongLocale = $mockData;
+        $dataWrongLocale['lang'] = 'de_DE';
+
+        $response = $this->post('spellcheck', ['ajax' => true] + $dataWrongLocale);
         $this->assertEquals(400, $response->getStatusCode());
         $jsonBody = json_decode($response->getBody());
         $this->assertEquals(_t(
             'SilverStripe\\SpellCheck\\Handling\\.InvalidLocale',
             'Not supported locale'
-        ), $jsonBody->error->errstr);
+        ), $jsonBody->error);
     }
 }

--- a/tests/SpellControllerTest.php
+++ b/tests/SpellControllerTest.php
@@ -119,6 +119,55 @@ class SpellControllerTest extends FunctionalTest
     }
 
     /**
+     * @param string $lang
+     * @param int $expectedStatusCode
+     * @dataProvider langProvider
+     */
+    public function testBothLangAndLocaleInputResolveToLocale($lang, $expectedStatusCode)
+    {
+        $this->logInWithPermission('ADMIN');
+        Config::modify()->set(SpellController::class, 'enable_security_token', false);
+
+        $mockData = [
+            'ajax' => true,
+            'method' => 'spellcheck',
+            'lang' => $lang,
+            'text' => 'Collor is everywhere',
+        ];
+        $response = $this->post('spellcheck', $mockData);
+        $this->assertEquals($expectedStatusCode, $response->getStatusCode());
+    }
+
+    /**
+     * @return array[]
+     */
+    public function langProvider()
+    {
+        return [
+            'english_language' => [
+                'en', // assumes en_US is the default locale for "en" language
+                200,
+            ],
+            'english_locale' => [
+                'en_NZ',
+                200,
+            ],
+            'invalid_language' => [
+                'ru',
+                400,
+            ],
+            'other_valid_language' => [
+                'fr', // assumes fr_FR is the default locale for "en" language
+                200,
+            ],
+            'other_valid_locale' => [
+                'fr_FR',
+                200,
+            ],
+        ];
+    }
+
+    /**
      * Ensure that invalid input is correctly rejected
      */
     public function testInputRejection()


### PR DESCRIPTION
This updates the SpellController API a little to work with the new IO data formats for TinyMCE 4 - see here https://www.tinymce.com/docs/plugins/spellchecker/#spellcheckerresponseformat

