### PR TITLE
FIX Allow errors to be returned as OK, and default language to the first locale

### DIFF
--- a/lang/en.yml
+++ b/lang/en.yml
@@ -1,6 +1,6 @@
 en:
   SilverStripe\SpellCheck\Handling\SpellController:
-    InvalidLocale: 'Not supported locale'
+    InvalidLocale: 'Not a supported locale'
     InvalidRequest: 'Invalid request'
     MissingData: 'Could not get raw post data'
     MissingProviders: 'No spellcheck module installed'

--- a/src/Handling/SpellController.php
+++ b/src/Handling/SpellController.php
@@ -21,7 +21,16 @@ class SpellController extends Controller
      * @var array
      * @config
      */
-    private static $locales = array();
+    private static $locales = [];
+
+    /**
+     * Optional: define the default locale for TinyMCE instances. If not defined, the first locale in the list of
+     * available locales will be used.
+     *
+     * @var string|bool
+     * @config
+     */
+    private static $default_locale = false;
 
     /**
      * Necessary permission required to spellcheck. Set to empty or null to disable restrictions.

--- a/src/Handling/SpellController.php
+++ b/src/Handling/SpellController.php
@@ -40,6 +40,14 @@ class SpellController extends Controller
     private static $enable_security_token = true;
 
     /**
+     * If true, all error messages will be returned with a 200 OK HTTP header code
+     *
+     * @var bool
+     * @config
+     */
+    private static $return_errors_as_ok = false;
+
+    /**
      * Dependencies required by this controller
      *
      * @var array
@@ -81,7 +89,7 @@ class SpellController extends Controller
     public static function get_locales()
     {
         // Default to current locale if none configured
-        return self::config()->locales ?: array(i18n::get_locale());
+        return self::config()->get('locales') ?: array(i18n::get_locale());
     }
 
     /**
@@ -116,18 +124,19 @@ class SpellController extends Controller
     }
 
     /**
-     * Set the error
+     * Set the error.
      *
      * @param string $message
      * @param int $code HTTP error code
      */
     protected function error($message, $code)
     {
-        $error = [
-            'error' => $message,
-        ];
+        // Some clients may require errors to be returned with a 200 OK header code
+        if ($this->config()->get('return_errors_as_ok')) {
+            $code = 200;
+        }
 
-        return $this->result($error, $code);
+        return $this->result(['error' => $message], $code);
     }
 
     public function index()
@@ -167,7 +176,7 @@ class SpellController extends Controller
         // Check locale
         $locale = $this->getLocale($data);
         if (!$locale) {
-            return $this->error(_t(__CLASS__ . '.InvalidLocale', 'Not supported locale'), 400);
+            return $this->error(_t(__CLASS__ . '.InvalidLocale', 'Not a supported locale'), 400);
         }
 
         // Check provider

--- a/tests/Handling/SpellCheckMiddlewareTest.php
+++ b/tests/Handling/SpellCheckMiddlewareTest.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace SilverStripe\Spellcheck\Tests\Handling;
+
+use SilverStripe\Core\Config\Config;
+use SilverStripe\Dev\SapphireTest;
+use SilverStripe\SpellCheck\Handling\SpellCheckMiddleware;
+use SilverStripe\SpellCheck\Handling\SpellController;
+
+class SpellCheckMiddlewareTest extends SapphireTest
+{
+    public function testGetDefaultLocale()
+    {
+        $middleware = new SpellCheckMiddleware();
+
+        Config::modify()->set(SpellController::class, 'default_locale', 'foo');
+        $this->assertSame('foo', $middleware->getDefaultLocale(), 'Returns configured default');
+
+        Config::modify()
+            ->set(SpellController::class, 'default_locale', false)
+            ->set(SpellController::class, 'locales', ['foo_BAR', 'bar_BAZ']);
+        $this->assertSame('foo_BAR', $middleware->getDefaultLocale(), 'Returns first in `locales`');
+    }
+}


### PR DESCRIPTION
This pull request makes two backwards compatible bug fixes:

* Allow errors to be returned as a 200 OK header rather than 4xx or 5xx (TinyMCE expects them to be 200)
* Allow configurable default locale (TinyMCE's `spellcheck_language` setting), or fallback to picking the first language from the `SpellController.locales` array, rather than providing the default "en" which doesn't actually work

Parent issue: https://github.com/silverstripe/cwp/issues/79