### PR TITLE
FIX Updating spellchecker to use new HTTPCacheControl API

### DIFF
--- a/code/handling/SpellController.php
+++ b/code/handling/SpellController.php
@@ -197,8 +197,13 @@ class SpellController extends Controller {
 	 */
 	protected function setHeaders() {
 		// Set headers
-		HTTP::set_cache_age(0);
-		HTTP::add_cache_headers($this->response);
+        if (class_exists('HTTPCacheControl')) {
+            HTTPCacheControl::singleton()->disableCache();
+        } else {
+            HTTP::set_cache_age(0);
+            HTTP::add_cache_headers($this->response);
+        }
+
 		$this->response
 			->addHeader('Content-Type', 'application/json')
 			->addHeader('Content-Encoding', 'UTF-8')


### PR DESCRIPTION
Currently an `E_USER_WARNING` is raised if the Cache-Control header is added to a response instead of using `HTTPCacheControl`. This updates spellchecker so this warning is not raised.